### PR TITLE
[dy] Add doc service resources

### DIFF
--- a/gcp/load_balancer.tf
+++ b/gcp/load_balancer.tf
@@ -76,3 +76,49 @@ resource "google_compute_global_forwarding_rule" "frontend" {
   port_range = "80"
   ip_address = google_compute_global_address.ip.address
 }
+
+# Create load balancer resources for DBT docs server, uncomment if needed
+# resource "google_compute_global_address" "docs_ip" {
+#   name = "${var.app_name}-service-docs-ip"
+# }
+
+# resource "google_compute_region_network_endpoint_group" "cloudrun_docs_neg" {
+#   name                  = "${var.app_name}-docs-neg"
+#   network_endpoint_type = "SERVERLESS"
+#   region                = var.region
+#   cloud_run {
+#     service = google_cloud_run_service.dbt_docs_service.name
+#   }
+# }
+
+# resource "google_compute_backend_service" "docs_backend" {
+#   name      = "${var.app_name}-docs-backend"
+
+#   protocol  = "HTTP"
+#   port_name = "http"
+#   timeout_sec = 30
+
+#   backend {
+#     group = google_compute_region_network_endpoint_group.cloudrun_docs_neg.id
+#   }
+
+#   security_policy = google_compute_security_policy.policy.name
+# }
+
+# resource "google_compute_url_map" "docs_url_map" {
+#   name            = "${var.app_name}-docs-urlmap"
+
+#   default_service = google_compute_backend_service.docs_backend.id
+# }
+
+# resource "google_compute_target_http_proxy" "docs_http_proxy" {
+#   name    = "${var.app_name}-docs-http-proxy"
+#   url_map = google_compute_url_map.docs_url_map.id
+# }
+
+# resource "google_compute_global_forwarding_rule" "docs_frontend" {
+#   name       = "${var.app_name}-docs-frontend"
+#   target     = google_compute_target_http_proxy.docs_http_proxy.id
+#   port_range = "80"
+#   ip_address = google_compute_global_address.docs_ip.address
+# }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -178,3 +178,76 @@ resource "google_cloud_run_service_iam_member" "run_all_users" {
 output "service_ip" {
   value = google_compute_global_address.ip.address
 }
+
+
+# Create the Cloud Run DBT Docs service and corresponding resources, uncomment if needed
+# resource "google_cloud_run_service" "dbt_docs_service" {
+#   name = "${var.app_name}-docs1"
+#   location = var.region
+
+#   template {
+#     spec {
+#       containers {
+#         image = var.docker_image
+#         ports {
+#           container_port = 7789
+#         }
+#         resources {
+#           limits = {
+#             cpu     = var.container_cpu
+#             memory  = var.container_memory
+#           }
+#         }
+#         env {
+#           name  = "FILESTORE_IP_ADDRESS"
+#           value = google_filestore_instance.instance.networks[0].ip_addresses[0]
+#         }
+#         env {
+#           name  = "FILE_SHARE_NAME"
+#           value = "share1"
+#         }
+#         env {
+#           name  = "DBT_DOCS_INSTANCE"
+#           value = "1"
+#         }
+#       }
+#     }
+
+#     metadata {
+#       annotations = {
+#         "autoscaling.knative.dev/minScale"         = "1"
+#         "run.googleapis.com/execution-environment" = "gen2"
+#         "run.googleapis.com/vpc-access-connector"  = google_vpc_access_connector.connector.id
+#         "run.googleapis.com/vpc-access-egress"     = "private-ranges-only"
+#       }
+#     }
+#   }
+
+#   traffic {
+#     percent         = 100
+#     latest_revision = true
+#   }
+
+#   metadata {
+#     annotations = {
+#       "run.googleapis.com/launch-stage" = "BETA"
+#       "run.googleapis.com/ingress"      = "internal-and-cloud-load-balancing"
+#     }
+#   }
+
+#   autogenerate_revision_name = true
+
+#   # Waits for the Cloud Run API to be enabled
+#   depends_on = [google_project_service.cloudrun]
+# }
+
+# resource "google_cloud_run_service_iam_member" "run_all_users_docs" {
+#   service  = google_cloud_run_service.dbt_docs_service.name
+#   location = google_cloud_run_service.dbt_docs_service.location
+#   role     = "roles/run.invoker"
+#   member   = "allUsers"
+# }
+
+# output "docs_service_ip" {
+#   value = google_compute_global_address.docs_ip.address
+# }


### PR DESCRIPTION
# Summary

Add docs service resources to serve docs for DBT. I commented it out because I don't think most people would want to have this included by default. Most of the resources for the docs service are similar to the original mage service. I think we  could potentially decrease the amount of resources for the docs service, but I didn't test that.
<!-- Brief summary of what your code does -->

# Tests

tested with gcp

docs service ip: 34.111.121.55
mage service ip: 34.110.155.60
<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
