### PR TITLE
[xy] Add terraform script for digital ocean.

### DIFF
--- a/digitalocean/main.tf
+++ b/digitalocean/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_version = ">= 1.2.0"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {}
+
+resource "digitalocean_ssh_key" "ssh_key" {
+  name = "${var.app_name}-${var.app_environment}-key"
+  public_key = file(var.ssh_pub_key)
+}
+
+resource "digitalocean_droplet" "app" {
+  name      = "${var.app_name}-${var.app_environment}"
+  image     = "docker-20-04"
+  region    = var.region
+  size      = "s-${var.cpu}vcpu-${var.memory}gb"
+  ssh_keys = [
+    digitalocean_ssh_key.ssh_key.id
+  ]
+}
+
+resource "digitalocean_volume" "volume" {
+  region                  = var.region
+  name                    = "${var.app_name}-${var.app_environment}-volume"
+  size                    = 20
+  initial_filesystem_type = "ext4"
+}
+
+resource "digitalocean_volume_attachment" "attachment" {
+  droplet_id = digitalocean_droplet.app.id
+  volume_id  = digitalocean_volume.volume.id
+}
+
+data "http" "myip" {
+  url = "http://ipv4.icanhazip.com"
+}
+
+resource "digitalocean_firewall" "web" {
+  name = "${var.app_name}-${var.app_environment}-firewall"
+
+  droplet_ids = [digitalocean_droplet.app.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "6789"
+    source_addresses = ["${chomp(data.http.myip.response_body)}/32"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+output "ip_address" {
+  value = digitalocean_droplet.app.ipv4_address
+  description = "The public IP address of your Droplet application."
+}

--- a/digitalocean/variables.tf
+++ b/digitalocean/variables.tf
@@ -1,0 +1,33 @@
+variable "app_environment" {
+  type        = string
+  description = "Application Environment"
+  default     = "production"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application Name"
+  default     = "mage-data-prep"
+}
+
+variable "cpu" {
+  description = "Instance CPU"
+  default     = "1"
+}
+
+variable "memory" {
+  description = "Instance memory in GB"
+  default     = "1"
+}
+
+variable "region" {
+  type        = string
+  description = "Region of the datacenters"
+  default     = "sfo3"
+}
+
+
+variable "ssh_pub_key" {
+  description = "Instance memory in GB"
+  default     = "~/.ssh/id_rsa.pub"
+}


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Add terraform script for digital ocean.
I choose to use Droplet instead of App Platform for the following reasons
* Firewall is supported in Droplet but not App Platform
* Volume is supported in Droplet but not App Platform

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
