### PR TITLE
Restrict access to the shared EFS volume

### DIFF
--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -26,8 +26,7 @@ resource "aws_security_group" "mount_target_security_group" {
     from_port        = 2049
     to_port          = 2049
     protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    security_groups  = [aws_security_group.service_security_group.id]
   }
 
   tags = {


### PR DESCRIPTION
# Summary
Limiting access to the ECS tasks to the EFS volume instead of allowing access from all IPs.

# Tests
AFAIK there shouldn't be any reason why any other resources than the ECS tasks need write access to the EFS volume.

cc:
@tommydangerous 