### PR TITLE
[xy] Use subnet_ids instead of network_profile_id in azure terraform scripts

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -34,7 +34,8 @@ resource "azurerm_container_group" "container_group" {
   resource_group_name = azurerm_resource_group.resource_group.name
   ip_address_type     = "Private"
   os_type             = "Linux"
-  network_profile_id  = azurerm_network_profile.containergroup_profile.id
+  # network_profile_id  = azurerm_network_profile.containergroup_profile.id
+  subnet_ids          = [azurerm_subnet.sn-aci.id]
 
   container {
     name      = "${var.app_name}-${var.app_environment}-container"


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Use subnet_ids instead of network_profile_id in azure terraform scripts

This fixes the error
![image](https://user-images.githubusercontent.com/80284865/221012265-43c73413-af0f-442a-a5ba-0062ba0baaa0.png)


# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
