### PR TITLE
[dy] AWS codepipeline for deploying Mage

### DIFF
--- a/aws-code-pipeline/build.tf
+++ b/aws-code-pipeline/build.tf
@@ -1,0 +1,96 @@
+data "template_file" "buildspec" {
+    template = "${file("${path.module}/buildspec.yml")}"
+    vars = {
+        container_name = "eng-test-production-container"
+        image_uri = "679849156117.dkr.ecr.us-west-2.amazonaws.com/codepipeline-test:latest"
+    }
+}
+
+resource "aws_codebuild_project" "codebuild" {
+  name          = "${var.code_pipeline_name}-build-docker"
+  description   = "Build docker image and push to ECR"
+  build_timeout = "5"
+  service_role  = aws_iam_role.codebuild_role.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:4.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode = true
+
+    environment_variable {
+      name  = "AWS_DEFAULT_REGION"
+      value = var.aws_region
+    }
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = var.aws_account_id
+    }
+
+    environment_variable {
+      name  = "IMAGE_TAG"
+      value = var.ecr_image_tag
+    }
+    
+    environment_variable {
+      name  = "IMAGE_REPO_NAME"
+      value = var.ecr_repo_name
+    }
+
+    environment_variable {
+      name  = "AWS_ACCESS_KEY_ID"
+      value = var.AWS_ACCESS_KEY_ID
+    }
+
+    environment_variable {
+      name  = "AWS_SECRET_ACCESS_KEY"
+      value = var.AWS_SECRET_ACCESS_KEY
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {}
+  }
+
+  source {
+    type            = "CODEPIPELINE"
+  }
+
+  source_version = "main"
+}
+
+resource "aws_codebuild_project" "ecr-codebuild" {
+  name          = "${var.code_pipeline_name}-create-imagedefinitions"
+  description   = "Create imagedefinitions.json file"
+  build_timeout = "5"
+  service_role  = aws_iam_role.codebuild_role.arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:4.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode = true
+  }
+
+  logs_config {
+    cloudwatch_logs {}
+  }
+
+  source {
+    type            = "CODEPIPELINE"
+    buildspec = data.template_file.buildspec.rendered
+  }
+
+  source_version = "main"
+}

--- a/aws-code-pipeline/build.tf
+++ b/aws-code-pipeline/build.tf
@@ -10,7 +10,7 @@ resource "aws_codebuild_project" "codebuild" {
   name          = "${var.code_pipeline_name}-build-docker"
   description   = "Build docker image and push to ECR"
   build_timeout = "5"
-  service_role  = aws_iam_role.codebuild_role.arn
+  service_role  = aws_iam_role.codepipeline_role.arn
 
   artifacts {
     type = "CODEPIPELINE"
@@ -69,7 +69,7 @@ resource "aws_codebuild_project" "ecr-codebuild" {
   name          = "${var.code_pipeline_name}-create-imagedefinitions"
   description   = "Create imagedefinitions.json file"
   build_timeout = "5"
-  service_role  = aws_iam_role.codebuild_role.arn
+  service_role  = aws_iam_role.codepipeline_role.arn
 
   artifacts {
     type = "CODEPIPELINE"

--- a/aws-code-pipeline/build.tf
+++ b/aws-code-pipeline/build.tf
@@ -1,8 +1,8 @@
 data "template_file" "buildspec" {
     template = "${file("${path.module}/buildspec.yml")}"
     vars = {
-        container_name = "eng-test-production-container"
-        image_uri = "679849156117.dkr.ecr.us-west-2.amazonaws.com/codepipeline-test:latest"
+        container_name = var.ecs_container_name
+        image_uri = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.ecr_repo_name}:${var.ecr_image_tag}"
     }
 }
 
@@ -13,7 +13,7 @@ resource "aws_codebuild_project" "codebuild" {
   service_role  = aws_iam_role.codebuild_role.arn
 
   artifacts {
-    type = "NO_ARTIFACTS"
+    type = "CODEPIPELINE"
   }
 
   environment {

--- a/aws-code-pipeline/build.tf
+++ b/aws-code-pipeline/build.tf
@@ -1,9 +1,9 @@
 data "template_file" "buildspec" {
-    template = "${file("${path.module}/buildspec.yml")}"
-    vars = {
-        container_name = var.ecs_container_name
-        image_uri = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.ecr_repo_name}:${var.ecr_image_tag}"
-    }
+  template = file("${path.module}/buildspec.yml")
+  vars = {
+    container_name = var.ecs_container_name
+    image_uri      = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.ecr_repo_name}:${var.ecr_image_tag}"
+  }
 }
 
 resource "aws_codebuild_project" "codebuild" {
@@ -21,7 +21,7 @@ resource "aws_codebuild_project" "codebuild" {
     image                       = "aws/codebuild/standard:4.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
-    privileged_mode = true
+    privileged_mode             = true
 
     environment_variable {
       name  = "AWS_DEFAULT_REGION"
@@ -37,7 +37,7 @@ resource "aws_codebuild_project" "codebuild" {
       name  = "IMAGE_TAG"
       value = var.ecr_image_tag
     }
-    
+
     environment_variable {
       name  = "IMAGE_REPO_NAME"
       value = var.ecr_repo_name
@@ -59,7 +59,7 @@ resource "aws_codebuild_project" "codebuild" {
   }
 
   source {
-    type            = "CODEPIPELINE"
+    type = "CODEPIPELINE"
   }
 
   source_version = "main"
@@ -80,7 +80,7 @@ resource "aws_codebuild_project" "ecr-codebuild" {
     image                       = "aws/codebuild/standard:4.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
-    privileged_mode = true
+    privileged_mode             = true
   }
 
   logs_config {
@@ -88,7 +88,7 @@ resource "aws_codebuild_project" "ecr-codebuild" {
   }
 
   source {
-    type            = "CODEPIPELINE"
+    type      = "CODEPIPELINE"
     buildspec = data.template_file.buildspec.rendered
   }
 

--- a/aws-code-pipeline/buildspec.yml
+++ b/aws-code-pipeline/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   build:
     commands:
-       - printf '[{"name":"${container_name}","imageUri":"${image_uri}"}]' > imagedefinitions.json
+      - printf '[{"name":"${container_name}","imageUri":"${image_uri}"}]' > imagedefinitions.json
 artifacts:
   files:
-    - '**/*'
+    - imagedefinitions.json

--- a/aws-code-pipeline/buildspec.yml
+++ b/aws-code-pipeline/buildspec.yml
@@ -1,0 +1,9 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+       - printf '[{"name":"${container_name}","imageUri":"${image_uri}"}]' > imagedefinitions.json
+artifacts:
+  files:
+    - '**/*'

--- a/aws-code-pipeline/event.tf
+++ b/aws-code-pipeline/event.tf
@@ -1,3 +1,26 @@
+resource "aws_cloudwatch_event_rule" "codecommit_push" {
+  name     = "${var.code_pipeline_name}-codecommit-push"
+  role_arn = aws_iam_role.event_role.arn
+
+  event_pattern = jsonencode({
+    source      = ["aws.codecommit"]
+    detail-type = ["CodeCommit Repository State Change"]
+    resources   = ["arn:aws:codecommit:${var.aws_region}:${var.aws_account_id}:${var.codecommit_repo_name}"]
+    detail = {
+      event         = ["referenceCreated", "referenceUpdated"]
+      referenceType = ["branch"]
+      referenceName = [var.codecommit_branch]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "codecommit_push_target" {
+  rule      = aws_cloudwatch_event_rule.codecommit_push.name
+  target_id = aws_codepipeline.codepipeline.name
+  arn       = aws_codepipeline.codepipeline.arn
+  role_arn  = aws_iam_role.event_role.arn
+}
+
 resource "aws_cloudwatch_event_rule" "ecr_image_push" {
   name     = "${var.code_pipeline_name}-ecr-image-push"
   role_arn = aws_iam_role.event_role.arn
@@ -15,7 +38,7 @@ resource "aws_cloudwatch_event_rule" "ecr_image_push" {
   })
 }
 
-resource "aws_cloudwatch_event_target" "ecr_image_push" {
+resource "aws_cloudwatch_event_target" "ecr_image_push_target" {
   rule      = aws_cloudwatch_event_rule.ecr_image_push.name
   target_id = aws_codepipeline.ecr-codepipeline.name
   arn       = aws_codepipeline.ecr-codepipeline.arn

--- a/aws-code-pipeline/event.tf
+++ b/aws-code-pipeline/event.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_event_rule" "ecr_image_push" {
   name     = "${var.code_pipeline_name}-ecr-image-push"
-  role_arn = aws_iam_role.codepipeline_role.arn
+  role_arn = aws_iam_role.event_role.arn
 
   event_pattern = jsonencode({
     source      = ["aws.ecr"]
@@ -19,5 +19,5 @@ resource "aws_cloudwatch_event_target" "ecr_image_push" {
   rule      = aws_cloudwatch_event_rule.ecr_image_push.name
   target_id = aws_codepipeline.ecr-codepipeline.name
   arn       = aws_codepipeline.ecr-codepipeline.arn
-  role_arn  = aws_iam_role.codepipeline_role.arn
+  role_arn  = aws_iam_role.event_role.arn
 }

--- a/aws-code-pipeline/event.tf
+++ b/aws-code-pipeline/event.tf
@@ -1,0 +1,23 @@
+resource "aws_cloudwatch_event_rule" "ecr_image_push" {
+  name     = "${var.code_pipeline_name}-ecr-image-push"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  event_pattern = jsonencode({
+    source      = ["aws.ecr"]
+    detail-type = ["ECR Image Action"]
+
+    detail = {
+      repository-name = [var.ecr_repo_name]
+      image-tag       = [var.ecr_image_tag]
+      action-type     = ["PUSH"]
+      result          = ["SUCCESS"]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "ecr_image_push" {
+  rule      = aws_cloudwatch_event_rule.ecr_image_push.name
+  target_id = aws_codepipeline.ecr-codepipeline.name
+  arn       = aws_codepipeline.ecr-codepipeline.arn
+  role_arn  = aws_iam_role.codepipeline_role.arn
+}

--- a/aws-code-pipeline/iam.tf
+++ b/aws-code-pipeline/iam.tf
@@ -1,4 +1,17 @@
+# Adjust AWS permissions as necessary
 data "aws_iam_policy_document" "codepipeline_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "iam:PassRole"
+    ]
+
+    resources = [
+      "arn:aws:iam::${var.aws_account_id}:role/${var.ecs_task_role_name}"
+    ]
+  }
+
   statement {
     effect = "Allow"
 
@@ -14,12 +27,12 @@ data "aws_iam_policy_document" "codepipeline_policy" {
   statement {
     effect   = "Allow"
     actions  = [
-        "codecommit:CancelUploadArchive",
-        "codecommit:GetBranch",
-        "codecommit:GetCommit",
-        "codecommit:GetRepository",
-        "codecommit:GetUploadArchiveStatus",
-        "codecommit:UploadArchive"
+      "codecommit:CancelUploadArchive",
+      "codecommit:GetBranch",
+      "codecommit:GetCommit",
+      "codecommit:GetRepository",
+      "codecommit:GetUploadArchiveStatus",
+      "codecommit:UploadArchive"
     ]
     resources = ["*"]
   }
@@ -27,12 +40,12 @@ data "aws_iam_policy_document" "codepipeline_policy" {
   statement {
     effect   = "Allow"
     actions  = [
-        "codedeploy:CreateDeployment",
-        "codedeploy:GetApplication",
-        "codedeploy:GetApplicationRevision",
-        "codedeploy:GetDeployment",
-        "codedeploy:GetDeploymentConfig",
-        "codedeploy:RegisterApplicationRevision"
+      "codedeploy:CreateDeployment",
+      "codedeploy:GetApplication",
+      "codedeploy:GetApplicationRevision",
+      "codedeploy:GetDeployment",
+      "codedeploy:GetDeploymentConfig",
+      "codedeploy:RegisterApplicationRevision"
     ]
     resources = ["*"]
   }
@@ -41,35 +54,15 @@ data "aws_iam_policy_document" "codepipeline_policy" {
     effect = "Allow"
 
     actions = [
-        "codebuild:BatchGetBuilds",
-        "codebuild:StartBuild",
-        "codebuild:BatchGetBuildBatches",
-        "codebuild:StartBuildBatch",
-        "codebuild:CreateReportGroup",
-        "codebuild:CreateReport",
-        "codebuild:UpdateReport",
-        "codebuild:BatchPutTestCases",
-        "codebuild:BatchPutCodeCoverages"
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-        "elasticbeanstalk:*",
-        "ec2:*",
-        "elasticloadbalancing:*",
-        "autoscaling:*",
-        "cloudwatch:*",
-        "s3:*",
-        "sns:*",
-        "cloudformation:*",
-        "rds:*",
-        "sqs:*",
-        "ecs:*"
+      "codebuild:BatchGetBuilds",
+      "codebuild:StartBuild",
+      "codebuild:BatchGetBuildBatches",
+      "codebuild:StartBuildBatch",
+      "codebuild:CreateReportGroup",
+      "codebuild:CreateReport",
+      "codebuild:UpdateReport",
+      "codebuild:BatchPutTestCases",
+      "codebuild:BatchPutCodeCoverages"
     ]
 
     resources = ["*"]
@@ -79,33 +72,52 @@ data "aws_iam_policy_document" "codepipeline_policy" {
     effect = "Allow"
 
     actions = [
-        "ecr:DescribeImages",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeListeners",
+      "elasticloadbalancing:ModifyListener",
+      "elasticloadbalancing:DescribeRules",
+      "elasticloadbalancing:ModifyRule",
+      "lambda:InvokeFunction",
+      "cloudwatch:DescribeAlarms",
+      "sns:Publish",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:*",
+      "ecs:*"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ecr:DescribeImages",
     ]
 
     resources = ["*"]
   }
 }
 
-data "aws_iam_policy_document" "pipeline_assume_role" {
+data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
 
     principals {
       type        = "Service"
-      identifiers = ["codepipeline.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
-data "aws_iam_policy_document" "build_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["codebuild.amazonaws.com"]
+      identifiers = [
+        "codepipeline.amazonaws.com",
+        "codebuild.amazonaws.com",
+        "events.amazonaws.com"
+      ]
     }
 
     actions = ["sts:AssumeRole"]
@@ -114,12 +126,12 @@ data "aws_iam_policy_document" "build_assume_role" {
 
 resource "aws_iam_role" "codepipeline_role" {
   name               = "${var.code_pipeline_name}-role"
-  assume_role_policy = data.aws_iam_policy_document.pipeline_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role" "codebuild_role" {
   name               = "${var.code_pipeline_name}-build-role"
-  assume_role_policy = data.aws_iam_policy_document.build_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "codepipeline_policy" {

--- a/aws-code-pipeline/iam.tf
+++ b/aws-code-pipeline/iam.tf
@@ -124,24 +124,34 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
+data "aws_iam_policy_document" "event_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "codepipeline:StartPipelineExecution"
+    ]
+
+    resources = [
+      aws_codepipeline.ecr-codepipeline.arn
+    ]
+  }
+}
+
 resource "aws_iam_role" "codepipeline_role" {
   name               = "${var.code_pipeline_name}-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  inline_policy {
+    name   = "${var.code_pipeline_name}-policy"
+    policy = data.aws_iam_policy_document.codepipeline_policy.json
+  }
 }
 
-resource "aws_iam_role" "codebuild_role" {
-  name               = "${var.code_pipeline_name}-build-role"
+resource "aws_iam_role" "event_role" {
+  name               = "${var.code_pipeline_name}-event-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
-}
-
-resource "aws_iam_role_policy" "codepipeline_policy" {
-  name   = "${var.code_pipeline_name}-policy"
-  role   = aws_iam_role.codepipeline_role.id
-  policy = data.aws_iam_policy_document.codepipeline_policy.json
-}
-
-resource "aws_iam_role_policy" "codebuild_policy" {
-  name   = "${var.code_pipeline_name}-build-policy"
-  role   = aws_iam_role.codebuild_role.id
-  policy = data.aws_iam_policy_document.codepipeline_policy.json
+  inline_policy {
+    name   = "${var.code_pipeline_name}-ecr-event-policy"
+    policy = data.aws_iam_policy_document.event_policy.json
+  }
 }

--- a/aws-code-pipeline/iam.tf
+++ b/aws-code-pipeline/iam.tf
@@ -133,6 +133,7 @@ data "aws_iam_policy_document" "event_policy" {
     ]
 
     resources = [
+      aws_codepipeline.codepipeline.arn,
       aws_codepipeline.ecr-codepipeline.arn
     ]
   }

--- a/aws-code-pipeline/iam.tf
+++ b/aws-code-pipeline/iam.tf
@@ -1,0 +1,135 @@
+data "aws_iam_policy_document" "codepipeline_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect   = "Allow"
+    actions  = [
+        "codecommit:CancelUploadArchive",
+        "codecommit:GetBranch",
+        "codecommit:GetCommit",
+        "codecommit:GetRepository",
+        "codecommit:GetUploadArchiveStatus",
+        "codecommit:UploadArchive"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect   = "Allow"
+    actions  = [
+        "codedeploy:CreateDeployment",
+        "codedeploy:GetApplication",
+        "codedeploy:GetApplicationRevision",
+        "codedeploy:GetDeployment",
+        "codedeploy:GetDeploymentConfig",
+        "codedeploy:RegisterApplicationRevision"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+        "codebuild:BatchGetBuilds",
+        "codebuild:StartBuild",
+        "codebuild:BatchGetBuildBatches",
+        "codebuild:StartBuildBatch",
+        "codebuild:CreateReportGroup",
+        "codebuild:CreateReport",
+        "codebuild:UpdateReport",
+        "codebuild:BatchPutTestCases",
+        "codebuild:BatchPutCodeCoverages"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+        "elasticbeanstalk:*",
+        "ec2:*",
+        "elasticloadbalancing:*",
+        "autoscaling:*",
+        "cloudwatch:*",
+        "s3:*",
+        "sns:*",
+        "cloudformation:*",
+        "rds:*",
+        "sqs:*",
+        "ecs:*"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+        "ecr:DescribeImages",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "pipeline_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["codepipeline.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "build_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["codebuild.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name               = "${var.code_pipeline_name}-role"
+  assume_role_policy = data.aws_iam_policy_document.pipeline_assume_role.json
+}
+
+resource "aws_iam_role" "codebuild_role" {
+  name               = "${var.code_pipeline_name}-build-role"
+  assume_role_policy = data.aws_iam_policy_document.build_assume_role.json
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name   = "${var.code_pipeline_name}-policy"
+  role   = aws_iam_role.codepipeline_role.id
+  policy = data.aws_iam_policy_document.codepipeline_policy.json
+}
+
+resource "aws_iam_role_policy" "codebuild_policy" {
+  name   = "${var.code_pipeline_name}-build-policy"
+  role   = aws_iam_role.codebuild_role.id
+  policy = data.aws_iam_policy_document.codepipeline_policy.json
+}

--- a/aws-code-pipeline/iam.tf
+++ b/aws-code-pipeline/iam.tf
@@ -25,8 +25,8 @@ data "aws_iam_policy_document" "codepipeline_policy" {
   }
 
   statement {
-    effect   = "Allow"
-    actions  = [
+    effect = "Allow"
+    actions = [
       "codecommit:CancelUploadArchive",
       "codecommit:GetBranch",
       "codecommit:GetCommit",
@@ -38,8 +38,8 @@ data "aws_iam_policy_document" "codepipeline_policy" {
   }
 
   statement {
-    effect   = "Allow"
-    actions  = [
+    effect = "Allow"
+    actions = [
       "codedeploy:CreateDeployment",
       "codedeploy:GetApplication",
       "codedeploy:GetApplicationRevision",
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "assume_role" {
     effect = "Allow"
 
     principals {
-      type        = "Service"
+      type = "Service"
       identifiers = [
         "codepipeline.amazonaws.com",
         "codebuild.amazonaws.com",

--- a/aws-code-pipeline/main.tf
+++ b/aws-code-pipeline/main.tf
@@ -112,7 +112,7 @@ resource "aws_codepipeline" "ecr-codepipeline" {
     name = "Deploy"
 
     action {
-      name            = "Deploy"
+      name            = "ECR_Deploy"
       category        = "Deploy"
       owner           = "AWS"
       provider        = "ECS"

--- a/aws-code-pipeline/main.tf
+++ b/aws-code-pipeline/main.tf
@@ -1,0 +1,128 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region  = "us-west-2"
+}
+
+resource "aws_s3_bucket" "codepipeline_bucket" {
+  bucket = var.s3_bucket_name
+}
+
+resource "aws_codepipeline" "codepipeline" {
+  name     = var.code_pipeline_name
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeCommit"
+      version          = "1"
+      output_artifacts = ["source_output"]
+
+      configuration = {
+        RepositoryName = var.codecommit_repo_name
+        BranchName = var.codecommit_branch
+        PollForSourceChanges = "true"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name             = "Build"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["source_output"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.codebuild.name
+      }
+    }
+  }
+}
+
+resource "aws_codepipeline" "ecr-codepipeline" {
+  name     = "${var.code_pipeline_name}-ecr"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+  }
+
+  stage {
+    name = "ECR_Source"
+
+    action {
+      name             = "ECR_Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      output_artifacts = ["ecr_docker_output"]
+      version          = "1"
+
+      configuration = {
+        RepositoryName = var.ecr_repo_name
+        ImageTag = var.ecr_image_tag
+      }
+    }
+  }
+
+  stage {
+    name = "ECR_Build"
+
+    action {
+      name             = "ECR_Build"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["ecr_docker_output"]
+      output_artifacts = ["ecr_build_artifact"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.ecr-codebuild.name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy"
+
+    action {
+      name            = "Deploy"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["ecr_build_artifact"]
+      version         = "1"
+
+      configuration = {
+        ClusterName = var.ecs_cluster_name
+        ServiceName = var.ecs_service_name
+      }
+    }
+  }
+}

--- a/aws-code-pipeline/main.tf
+++ b/aws-code-pipeline/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = "us-west-2"
+  region = "us-west-2"
 }
 
 resource "aws_s3_bucket" "codepipeline_bucket" {
@@ -38,8 +38,8 @@ resource "aws_codepipeline" "codepipeline" {
       output_artifacts = ["source_output"]
 
       configuration = {
-        RepositoryName = var.codecommit_repo_name
-        BranchName = var.codecommit_branch
+        RepositoryName       = var.codecommit_repo_name
+        BranchName           = var.codecommit_branch
         PollForSourceChanges = "true"
       }
     }
@@ -49,12 +49,12 @@ resource "aws_codepipeline" "codepipeline" {
     name = "Build"
 
     action {
-      name             = "Build"
-      category         = "Build"
-      owner            = "AWS"
-      provider         = "CodeBuild"
-      input_artifacts  = ["source_output"]
-      version          = "1"
+      name            = "Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["source_output"]
+      version         = "1"
 
       configuration = {
         ProjectName = aws_codebuild_project.codebuild.name
@@ -85,7 +85,7 @@ resource "aws_codepipeline" "ecr-codepipeline" {
 
       configuration = {
         RepositoryName = var.ecr_repo_name
-        ImageTag = var.ecr_image_tag
+        ImageTag       = var.ecr_image_tag
       }
     }
   }

--- a/aws-code-pipeline/main.tf
+++ b/aws-code-pipeline/main.tf
@@ -40,7 +40,7 @@ resource "aws_codepipeline" "codepipeline" {
       configuration = {
         RepositoryName       = var.codecommit_repo_name
         BranchName           = var.codecommit_branch
-        PollForSourceChanges = "true"
+        PollForSourceChanges = "false"
       }
     }
   }

--- a/aws-code-pipeline/variables.tf
+++ b/aws-code-pipeline/variables.tf
@@ -17,7 +17,7 @@ variable "aws_region" {
 variable "aws_account_id" {
   type        = string
   description = "AWS Account ID"
-  default     = "123456789012"
+  default     = "12345678910"
 }
 
 variable "s3_bucket_name" {
@@ -32,16 +32,16 @@ variable "code_pipeline_name" {
     default = "mage-codepipeline"
 }
 
-variable "ecr_image_tag" {
-  type        = string
-  description = "ECR docker image tag"
-  default     = "latest"
-}
-
 variable "ecr_repo_name" {
   type        = string
   description = "ECR repo name"
   default     = "ecr-repo-name"
+}
+
+variable "ecr_image_tag" {
+  type        = string
+  description = "ECR docker image tag"
+  default     = "latest"
 }
 
 variable "ecs_cluster_name" {
@@ -56,10 +56,22 @@ variable "ecs_service_name" {
   default     = "ecs-service-name"
 }
 
+variable "ecs_container_name" {
+  type        = string
+  description = "ECS container name"
+  default     = "ecs-container-name"
+}
+
+variable "ecs_task_role_name" {
+  type        = string
+  description = "ECS execution task role name"
+  default     = "ecs-task-role-name"
+}
+
 variable "codecommit_repo_name" {
   type        = string
   description = "Codecommit repo name"
-  default     = "codecommit-repo-name"
+  default     = "codecommit_repo_name"
 }
 
 variable "codecommit_branch" {

--- a/aws-code-pipeline/variables.tf
+++ b/aws-code-pipeline/variables.tf
@@ -1,10 +1,10 @@
 variable "AWS_ACCESS_KEY_ID" {
-  type = string
+  type    = string
   default = "AWS_ACCESS_KEY_ID"
 }
 
 variable "AWS_SECRET_ACCESS_KEY" {
-  type = string
+  type    = string
   default = "AWS_SECRET_ACCESS_KEY"
 }
 
@@ -21,15 +21,15 @@ variable "aws_account_id" {
 }
 
 variable "s3_bucket_name" {
-  type = string
+  type        = string
   description = "S3 bucket to store pipeline artifacts"
-  default = "s3-bucket-name"
+  default     = "s3-bucket-name"
 }
 
 variable "code_pipeline_name" {
-    type = string
-    description = "Name for AWS CodePipeline"
-    default = "mage-codepipeline"
+  type        = string
+  description = "Name for AWS CodePipeline"
+  default     = "mage-codepipeline"
 }
 
 variable "ecr_repo_name" {

--- a/aws-code-pipeline/variables.tf
+++ b/aws-code-pipeline/variables.tf
@@ -1,0 +1,69 @@
+variable "AWS_ACCESS_KEY_ID" {
+  type = string
+  default = "AWS_ACCESS_KEY_ID"
+}
+
+variable "AWS_SECRET_ACCESS_KEY" {
+  type = string
+  default = "AWS_SECRET_ACCESS_KEY"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS Region"
+  default     = "us-west-2"
+}
+
+variable "aws_account_id" {
+  type        = string
+  description = "AWS Account ID"
+  default     = "123456789012"
+}
+
+variable "s3_bucket_name" {
+  type = string
+  description = "S3 bucket to store pipeline artifacts"
+  default = "s3-bucket-name"
+}
+
+variable "code_pipeline_name" {
+    type = string
+    description = "Name for AWS CodePipeline"
+    default = "mage-codepipeline"
+}
+
+variable "ecr_image_tag" {
+  type        = string
+  description = "ECR docker image tag"
+  default     = "latest"
+}
+
+variable "ecr_repo_name" {
+  type        = string
+  description = "ECR repo name"
+  default     = "ecr-repo-name"
+}
+
+variable "ecs_cluster_name" {
+  type        = string
+  description = "ECS cluster name"
+  default     = "ecs-cluster-name"
+}
+
+variable "ecs_service_name" {
+  type        = string
+  description = "ECS service name"
+  default     = "ecs-service-name"
+}
+
+variable "codecommit_repo_name" {
+  type        = string
+  description = "Codecommit repo name"
+  default     = "codecommit-repo-name"
+}
+
+variable "codecommit_branch" {
+  type        = string
+  description = "Codecommit repo branch"
+  default     = "main"
+}


### PR DESCRIPTION
# Summary

Add terraform templates for deploying Mage to ECS from a CodeCommit repo with AWS CodePipeline. It will create 2 separate CodePipelines, one for building a docker image to ECR from a CodeCommit repository, and another one for reading from ECR and deploying to ECS.

In the `IAM` section, I have an inline policy with certain AWS permissions. I wasn't sure how to narrow the permissions down because I can't figure out exactly what permissions the CodePipeline needs to deploy to ECS. Is there a way to do that without manually trying a bunch of configurations?
<!-- Brief summary of what your code does -->

# Tests

tested on Mage AWS

<!-- How did you test your change? -->

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
