### PR TITLE
[xy] Specify ulimit_no_file env var in gcp terraform scripts.

### DIFF
--- a/gcp-dev/main.tf
+++ b/gcp-dev/main.tf
@@ -134,6 +134,10 @@ resource "google_cloud_run_service" "run_service" {
           value = "postgresql://${var.database_user}:${var.database_password}@/${var.app_name}-db?host=/cloudsql/${google_sql_database_instance.instance.connection_name}"
         }
         env {
+          name  = "ULIMIT_NO_FILE"
+          value = 16384
+        }
+        env {
           name  = "path_to_keyfile" # Try not to change this environment variable name
           value = var.path_to_keyfile
         }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -132,6 +132,10 @@ resource "google_cloud_run_service" "run_service" {
           name  = "MAGE_DATABASE_CONNECTION_URL"
           value = "postgresql://${var.database_user}:${var.database_password}@/${var.app_name}-db?host=/cloudsql/${google_sql_database_instance.instance.connection_name}"
         }
+        env {
+          name  = "ULIMIT_NO_FILE"
+          value = 16384
+        }
         # volume_mounts {
         #   mount_path = "/secrets/bigquery"
         #   name       = "secret-bigquery-key"


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Specify ulimit_no_file env var in gcp terraform scripts to solve "too many open files" error.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
