### PR TITLE
[mp] simplify GCP terraform template to use cloud run

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -60,39 +60,10 @@ resource "google_project_service" "sqladmin" {
   disable_on_destroy = false
 }
 
-# #############################################
-# #    Google Artifact Registry Repository    #
-# #############################################
-# # Create Artifact Registry Repository for Docker containers
-# resource "google_artifact_registry_repository" "my_docker_repo" {
-#   location = var.region
-#   repository_id = var.repository
-#   description = "My docker repository"
-#   format = "DOCKER"
-#   depends_on = [time_sleep.wait_30_seconds]
-# }
-# # Create a service account
-# resource "google_service_account" "docker_pusher" {
-#   account_id   = "docker-pusher"
-#   display_name = "Docker Container Pusher"
-#   depends_on =[time_sleep.wait_30_seconds]
-# }
-# # Give service account permission to push to the Artifact Registry Repository
-# resource "google_artifact_registry_repository_iam_member" "docker_pusher_iam" {
-#   location = google_artifact_registry_repository.my_docker_repo.location
-#   repository =  google_artifact_registry_repository.my_docker_repo.repository_id
-#   role   = "roles/artifactregistry.writer"
-#   member = "serviceAccount:${google_service_account.docker_pusher.email}"
-#   depends_on = [
-#     google_artifact_registry_repository.my_docker_repo,
-#     google_service_account.docker_pusher
-#     ]
-# }
-
 
 # Create the Cloud Run service
 resource "google_cloud_run_service" "run_service" {
-  name = var.app_name
+  name     = var.app_name
   location = var.region
 
   template {
@@ -104,8 +75,8 @@ resource "google_cloud_run_service" "run_service" {
         }
         resources {
           limits = {
-            cpu     = var.container_cpu
-            memory  = var.container_memory
+            cpu    = var.container_cpu
+            memory = var.container_memory
           }
         }
         env {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -53,7 +53,7 @@ variable "database_password" {
 variable "docker_image" {
   type        = string
   description = "The docker image to deploy to Cloud Run."
-  default     = "docker.io/mageai/mageai:latest"
+  default     = "mageai/mageai:latest"
 }
 
 variable "domain" {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -52,8 +52,8 @@ variable "database_password" {
 
 variable "docker_image" {
   type        = string
-  description = "The Docker image url in the Artifact Registry repository to be deployed to Cloud Run"
-  default     = "region-docker.pkg.dev/project_id/repository_name/mageai"
+  description = "The docker image to deploy to Cloud Run."
+  default     = "docker.io/mageai/mageai:latest"
 }
 
 variable "domain" {


### PR DESCRIPTION
# Summary
Remove artifact and use latest Mage image when creating Cloud Run from Docker Hub image. This is related to [this issue](https://github.com/mage-ai/mage-ai/issues/3033), informing us that Cloud Run now supports building directly from Docker Hub images.

# Tests
Internally, spinning up a Mage instance using `terraform apply`
