### PR TITLE
Fix Digital Ocean ssh_pub_key description

### DIFF
--- a/digitalocean/variables.tf
+++ b/digitalocean/variables.tf
@@ -28,6 +28,6 @@ variable "region" {
 
 
 variable "ssh_pub_key" {
-  description = "Instance memory in GB"
+  description = "Path to SSH public key"
   default     = "~/.ssh/id_rsa.pub"
 }


### PR DESCRIPTION
# Summary
Updates an incorrect description of a Digital Ocean variable for ssh_pub_key