### PR TITLE
Update AWS alb-tg health_check path

### DIFF
--- a/aws-dev/alb.tf
+++ b/aws-dev/alb.tf
@@ -60,7 +60,7 @@ resource "aws_lb_target_group" "target_group" {
     protocol            = "HTTP"
     matcher             = "200"
     timeout             = "5"
-    path                = "/api/kernels"
+    path                = "/api/status"
     unhealthy_threshold = "2"
   }
 

--- a/aws/alb.tf
+++ b/aws/alb.tf
@@ -21,17 +21,17 @@ resource "aws_security_group" "load_balancer_security_group" {
   vpc_id = aws_vpc.aws-vpc.id
 
   ingress {
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = ["${chomp(data.http.myip.response_body)}/32"]
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"]
   }
 
   ingress {
-    from_port        = 80
-    to_port          = 80
-    protocol         = "tcp"
-    cidr_blocks      = ["${chomp(data.http.myip.response_body)}/32"]
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"]
   }
 
   egress {
@@ -60,7 +60,7 @@ resource "aws_lb_target_group" "target_group" {
     protocol            = "HTTP"
     matcher             = "200"
     timeout             = "5"
-    path                = "/api/kernels"
+    path                = "/api/status"
     unhealthy_threshold = "2"
   }
 
@@ -76,7 +76,7 @@ resource "aws_lb_listener" "listener" {
   protocol          = "HTTP"
 
   default_action {
-     type             = "forward"
-     target_group_arn = aws_lb_target_group.target_group.id
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target_group.id
   }
 }


### PR DESCRIPTION
# Summary
updated the health check endpoint. 
Changed `/api/kernels` to `/api/status`

# Tests
I had issues with getting deployments healthy. @wangxiaoyou1993 helped me diagnose it and find the problem.

cc:
@wangxiaoyou1993 
