### PR TITLE
GCP: enable Filestore API via terraform

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -60,6 +60,11 @@ resource "google_project_service" "sqladmin" {
   disable_on_destroy = false
 }
 
+# Enable Cloud Filestore API
+resource "google_project_service" "filestore" {
+  service            = "file.googleapis.com"
+  disable_on_destroy = false
+}
 
 # Create the Cloud Run service
 resource "google_cloud_run_service" "run_service" {


### PR DESCRIPTION
# Summary
The Cloud Filestore API is missing to apply the filestore instance, we can do it manually but it is more cool if terraform does it for us 😎 

# Tests
I plan the code and apply it into my GCP project, all resources are deployed with success.